### PR TITLE
feat: remove withdrawExtra

### DIFF
--- a/packages/contracts/contracts/interfaces/IPayoutStrategy.sol
+++ b/packages/contracts/contracts/interfaces/IPayoutStrategy.sol
@@ -44,11 +44,6 @@ interface IPayoutStrategy {
   /// @param amount The amount
   function deposit(uint256 amount) external;
 
-  /// @notice Withdraw extra amount
-  /// @param receivers The receivers addresses
-  /// @param amounts The amounts
-  function withdrawExtra(address[] calldata receivers, uint256[] calldata amounts) external;
-
   /// @notice Claim funds for recipient
   /// @param params The claim params
   function claim(Claim calldata params) external;

--- a/packages/contracts/contracts/maci/Tally.sol
+++ b/packages/contracts/contracts/maci/Tally.sol
@@ -153,34 +153,6 @@ contract Tally is TallyBase, IPayoutStrategy, Pausable {
   }
 
   /// @inheritdoc IPayoutStrategy
-  function withdrawExtra(
-    address[] calldata receivers,
-    uint256[] calldata amounts
-  ) public override isInitialized onlyOwner whenNotPaused afterCooldown {
-    uint256 amountLength = amounts.length;
-    uint256 totalFunds = token.balanceOf(address(this));
-    uint256 sum = 0;
-
-    for (uint256 index = 0; index < amountLength; ) {
-      uint256 amount = amounts[index];
-      address receiver = receivers[index];
-      sum += amount;
-
-      if (sum > totalFunds) {
-        revert InvalidWithdrawal();
-      }
-
-      if (amount > 0) {
-        token.safeTransfer(receiver, amount);
-      }
-
-      unchecked {
-        index++;
-      }
-    }
-  }
-
-  /// @inheritdoc IPayoutStrategy
   function totalAmount() public view override returns (uint256) {
     return token.balanceOf(address(this));
   }


### PR DESCRIPTION
# Description

Remove unnecessary `withdrawExtra`. This reduces trust required in the `owner` as they cannot withdraw arbitrarily large amounts of funds 

## Additional Notes

<!-- If there are any additional notes, requirements or special instructions related to this PR, please specify them here. -->

## Related issue(s)

<!-- Please list here with closing keywords any issues that this pull request is related to (fix #$ISSUE_NUMBER). -->

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I run and verified that all tests pass acording to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
