### PR TITLE
feat: add deposit window to tally contract

### DIFF
--- a/packages/contracts/contracts/interfaces/IPayoutStrategy.sol
+++ b/packages/contracts/contracts/interfaces/IPayoutStrategy.sol
@@ -6,14 +6,14 @@ pragma solidity ^0.8.20;
 interface IPayoutStrategy {
   /// @notice Strategy initialization params
   struct StrategyInit {
-    /// @notice The cooldown duration for withdrawal extra funds
-    uint256 cooldownTime;
     /// @notice The max contribution amount
     uint256 maxContribution;
     /// @notice The max cap
     uint256 maxCap;
     /// @notice The payout token
     address payoutToken;
+    /// @notice The deposit window duration (in seconds) after poll ends
+    uint256 depositWindow;
   }
 
   /// @notice Claim params
@@ -36,9 +36,6 @@ interface IPayoutStrategy {
 
   /// @notice Total deposited amount
   function totalAmount() external view returns (uint256);
-
-  /// @notice The cooldown timeout
-  function cooldown() external view returns (uint256);
 
   /// @notice Deposit amount
   /// @param amount The amount

--- a/packages/contracts/deploy-config-example.json
+++ b/packages/contracts/deploy-config-example.json
@@ -77,10 +77,10 @@
     },
     "Tally": {
       "withPause": true,
-      "cooldownTime": "4838400",
       "maxCap": "10000000000000000000",
       "maxContribution": "5000000000000000000",
-      "payoutToken": "0x0000000000000000000000000000000000000000"
+      "payoutToken": "0x0000000000000000000000000000000000000000",
+      "depositWindow": "604800"
     }
   },
   "scroll_sepolia": {
@@ -160,10 +160,10 @@
     },
     "Tally": {
       "withPause": true,
-      "cooldownTime": "4838400",
       "maxCap": "10000000000000000000",
       "maxContribution": "5000000000000000000",
-      "payoutToken": "0x0000000000000000000000000000000000000000"
+      "payoutToken": "0x0000000000000000000000000000000000000000",
+      "depositWindow": "604800"
     }
   },
   "optimism": {
@@ -244,10 +244,10 @@
     },
     "Tally": {
       "withPause": true,
-      "cooldownTime": "4838400",
       "maxCap": "10000000000000000000",
       "maxContribution": "5000000000000000000",
-      "payoutToken": "0x0000000000000000000000000000000000000000"
+      "payoutToken": "0x0000000000000000000000000000000000000000",
+      "depositWindow": "604800"
     }
   },
   "arbitrum_sepolia": {
@@ -328,10 +328,10 @@
     },
     "Tally": {
       "withPause": true,
-      "cooldownTime": "4838400",
       "maxCap": "10000000000000000000",
       "maxContribution": "5000000000000000000",
-      "payoutToken": "0x0000000000000000000000000000000000000000"
+      "payoutToken": "0x0000000000000000000000000000000000000000",
+      "depositWindow": "604800"
     }
   },
   "localhost": {
@@ -412,10 +412,10 @@
     },
     "Tally": {
       "withPause": true,
-      "cooldownTime": "4838400",
       "maxCap": "10000000000000000000",
       "maxContribution": "5000000000000000000",
-      "payoutToken": "0x0000000000000000000000000000000000000000"
+      "payoutToken": "0x0000000000000000000000000000000000000000",
+      "depositWindow": "604800"
     }
   },
   "base_sepolia": {
@@ -496,10 +496,10 @@
     },
     "Tally": {
       "withPause": true,
-      "cooldownTime": "4838400",
       "maxCap": "10000000000000000000",
       "maxContribution": "5000000000000000000",
-      "payoutToken": "0x0000000000000000000000000000000000000000"
+      "payoutToken": "0x0000000000000000000000000000000000000000",
+      "depositWindow": "604800"
     }
   },
   "optimism_sepolia": {
@@ -585,10 +585,10 @@
     },
     "Tally": {
       "withPause": true,
-      "cooldownTime": "4838400",
       "maxCap": "10000000000000000000",
       "maxContribution": "5000000000000000000",
-      "payoutToken": "0x0000000000000000000000000000000000000000"
+      "payoutToken": "0x0000000000000000000000000000000000000000",
+      "depositWindow": "604800"
     }
   }
 }

--- a/packages/contracts/tasks/deploy/poll/01-poll.ts
+++ b/packages/contracts/tasks/deploy/poll/01-poll.ts
@@ -141,10 +141,10 @@ deployment.deployTask(EDeploySteps.Poll, "Deploy poll").then((task) =>
     // get the empty ballot root
     const emptyBallotRoot = await pollContract.emptyBallotRoot();
 
-    const cooldownTime =
-      deployment.getDeployConfigField<string | null>(EContracts.Tally, "cooldownTime") ?? ONE_WEEK_IN_SECONDS * 8;
     const maxContribution = deployment.getDeployConfigField<string>(EContracts.Tally, "maxContribution", true);
     const maxCap = deployment.getDeployConfigField<string>(EContracts.Tally, "maxCap", true);
+    const depositWindow =
+      deployment.getDeployConfigField<string | null>(EContracts.Tally, "depositWindow") ?? ONE_WEEK_IN_SECONDS;
     const withPause = deployment.getDeployConfigField<boolean | null>(EContracts.Tally, "withPause") ?? true;
     let payoutToken = deployment.getDeployConfigField<string>(EContracts.Tally, "payoutToken", true);
 
@@ -171,10 +171,10 @@ deployment.deployTask(EDeploySteps.Poll, "Deploy poll").then((task) =>
 
     await tallyContract
       .init({
-        cooldownTime,
         maxContribution,
         payoutToken,
         maxCap,
+        depositWindow,
       })
       .then((tx) => tx.wait());
 

--- a/packages/subgraph/schemas/schema.v1.graphql
+++ b/packages/subgraph/schemas/schema.v1.graphql
@@ -107,6 +107,7 @@ type Poll @entity {
 
 type Tally @entity {
   id: Bytes! # tally address
+  depositWindow: BigInt! # uint256 - duration in seconds after poll ends for deposits
   results: [TallyResult!]! @derivedFrom(field: "tally")
   claims: [Claim!]! @derivedFrom(field: "tally")
   deposits: [Deposit!]! @derivedFrom(field: "tally")

--- a/packages/subgraph/src/maci.ts
+++ b/packages/subgraph/src/maci.ts
@@ -5,6 +5,7 @@ import { DeployPoll as DeployPollEvent, SignUp as SignUpEvent, MACI as MaciContr
 import { Poll } from "../generated/schema";
 import { Poll as PollTemplate, Tally as TallyTemplate } from "../generated/templates";
 import { Poll as PollContract } from "../generated/templates/Poll/Poll";
+import { Tally as TallyContract } from "../generated/templates/Tally/Tally";
 
 import { ONE_BIG_INT, MESSAGE_TREE_ARITY } from "./utils/constants";
 import { createOrLoadMACI, createOrLoadUser, createOrLoadAccount, createOrLoadTally } from "./utils/entity";
@@ -48,7 +49,11 @@ export function handleDeployPoll(event: DeployPollEvent): void {
   // address of the new poll contract
   PollTemplate.create(Address.fromBytes(poll.id));
 
-  createOrLoadTally(contracts.tally, poll.id);
+  // Read depositWindow from the Tally contract
+  const tallyContract = TallyContract.bind(contracts.tally);
+  const depositWindow = tallyContract.depositWindow();
+
+  createOrLoadTally(contracts.tally, poll.id, depositWindow);
 
   // Start indexing the tally
   TallyTemplate.create(Address.fromBytes(contracts.tally));

--- a/packages/subgraph/src/utils/entity.ts
+++ b/packages/subgraph/src/utils/entity.ts
@@ -111,12 +111,13 @@ export const createOrLoadRecipient = (
   return recipient;
 };
 
-export const createOrLoadTally = (tally: Bytes, poll: Bytes): Tally => {
+export const createOrLoadTally = (tally: Bytes, poll: Bytes, depositWindow: GraphBN): Tally => {
   let entity = Tally.load(tally);
 
   if (!entity) {
     entity = new Tally(tally);
     entity.poll = poll;
+    entity.depositWindow = depositWindow;
     entity.save();
   }
 

--- a/packages/subgraph/tests/common.ts
+++ b/packages/subgraph/tests/common.ts
@@ -63,4 +63,8 @@ export function mockTallyContract(): void {
   createMockedFunction(DEFAULT_TALLY_ADDRESS, "poll", "poll():(address)").returns([
     ethereum.Value.fromAddress(DEFAULT_POLL_ADDRESS),
   ]);
+
+  createMockedFunction(DEFAULT_TALLY_ADDRESS, "depositWindow", "depositWindow():(uint256)").returns([
+    ethereum.Value.fromI32(604800), // 1 week in seconds
+  ]);
 }

--- a/packages/subgraph/tests/maci/maci.test.ts
+++ b/packages/subgraph/tests/maci/maci.test.ts
@@ -4,7 +4,7 @@ import { test, describe, afterEach, clearStore, assert, beforeAll } from "matchs
 
 import { Account, MACI, Poll, User } from "../../generated/schema";
 import { handleSignUp, handleDeployPoll } from "../../src/maci";
-import { DEFAULT_POLL_ADDRESS, mockMaciContract, mockPollContract } from "../common";
+import { DEFAULT_POLL_ADDRESS, mockMaciContract, mockPollContract, mockTallyContract } from "../common";
 
 import { createSignUpEvent, createDeployPollEvent } from "./utils";
 
@@ -14,6 +14,7 @@ describe("MACI", () => {
   beforeAll(() => {
     mockMaciContract();
     mockPollContract();
+    mockTallyContract();
   });
 
   afterEach(() => {


### PR DESCRIPTION

# Description

<!-- Please provide a detailed description of the pull request you are opening. -->

This pull request refactors the Tally contract's post-poll fund management by replacing the previous cooldown mechanism with a more explicit deposit window. This makes the period for depositing funds after a poll ends clearer and more configurable. The change is reflected across the Solidity contracts, deployment scripts, tests, and subgraph schema/indexing logic.

Key changes include:

**Smart Contract Logic Updates:**
- Removed the `cooldownTime` parameter and related logic. Added `depositWindow` parameter, which defines how long after a poll ends deposits are accepted. The contract now enforces deposit and claim actions based on this window, using new modifiers and error types. (`IPayoutStrategy.sol`, `Tally.sol`) [[1]](diffhunk://#diff-6918d43eeb98ac1c2e3daaa3f837b55b8788438fda9731b9ff6d60cb76d02d47L9-R16) [[2]](diffhunk://#diff-6918d43eeb98ac1c2e3daaa3f837b55b8788438fda9731b9ff6d60cb76d02d47L40-L42) [[3]](diffhunk://#diff-6a9a85581b368d5c4be6a5525bef3b5a921a4c386a1398068595df79a47ff8c3L32-R39) [[4]](diffhunk://#diff-6a9a85581b368d5c4be6a5525bef3b5a921a4c386a1398068595df79a47ff8c3L65-R70) [[5]](diffhunk://#diff-6a9a85581b368d5c4be6a5525bef3b5a921a4c386a1398068595df79a47ff8c3L91-R125) [[6]](diffhunk://#diff-6a9a85581b368d5c4be6a5525bef3b5a921a4c386a1398068595df79a47ff8c3L129-R149) [[7]](diffhunk://#diff-6a9a85581b368d5c4be6a5525bef3b5a921a4c386a1398068595df79a47ff8c3L149-R165) [[8]](diffhunk://#diff-6a9a85581b368d5c4be6a5525bef3b5a921a4c386a1398068595df79a47ff8c3L203-R219)

**Deployment and Configuration:**
- Updated the deployment configuration (`deploy-config-example.json`) to remove `cooldownTime` and add a `depositWindow` field for all environments. Deployment scripts now use this new parameter. (`deploy-config-example.json`, `01-poll.ts`) [[1]](diffhunk://#diff-72fb681a12f3aab50208c494e5c97da96da0f539a8317af7a6a701bd3257e732L80-R83) [[2]](diffhunk://#diff-72fb681a12f3aab50208c494e5c97da96da0f539a8317af7a6a701bd3257e732L163-R166) [[3]](diffhunk://#diff-72fb681a12f3aab50208c494e5c97da96da0f539a8317af7a6a701bd3257e732L247-R250) [[4]](diffhunk://#diff-72fb681a12f3aab50208c494e5c97da96da0f539a8317af7a6a701bd3257e732L331-R334) [[5]](diffhunk://#diff-72fb681a12f3aab50208c494e5c97da96da0f539a8317af7a6a701bd3257e732L415-R418) [[6]](diffhunk://#diff-72fb681a12f3aab50208c494e5c97da96da0f539a8317af7a6a701bd3257e732L499-R502) [[7]](diffhunk://#diff-72fb681a12f3aab50208c494e5c97da96da0f539a8317af7a6a701bd3257e732L588-R591) [[8]](diffhunk://#diff-c206fbcd967873c99d8390177e58c4547a8a734676de7291a46f81a2ad3b7fd0L144-R147) [[9]](diffhunk://#diff-c206fbcd967873c99d8390177e58c4547a8a734676de7291a46f81a2ad3b7fd0L174-R177)

**Testing Updates:**
- Refactored tests to use `depositWindow` instead of `cooldownTime`, and updated time travel logic to match the new deposit window semantics. (`Tally.test.ts`) [[1]](diffhunk://#diff-16b55ce2fcbe8eb39929a8a483cd5e76e2e5cd250bd021cca95d6d36c9347d0dL58-R60) [[2]](diffhunk://#diff-16b55ce2fcbe8eb39929a8a483cd5e76e2e5cd250bd021cca95d6d36c9347d0dL157-R160) [[3]](diffhunk://#diff-16b55ce2fcbe8eb39929a8a483cd5e76e2e5cd250bd021cca95d6d36c9347d0dL189-R203) [[4]](diffhunk://#diff-16b55ce2fcbe8eb39929a8a483cd5e76e2e5cd250bd021cca95d6d36c9347d0dL213-R216) [[5]](diffhunk://#diff-16b55ce2fcbe8eb39929a8a483cd5e76e2e5cd250bd021cca95d6d36c9347d0dL270-R270) [[6]](diffhunk://#diff-16b55ce2fcbe8eb39929a8a483cd5e76e2e5cd250bd021cca95d6d36c9347d0dR453-R455)

**Subgraph and Indexing:**
- Extended the subgraph schema and entity creation logic to track the `depositWindow` for each Tally, and updated event handlers and mocks accordingly. (`schema.v1.graphql`, `entity.ts`, `maci.ts`, `common.ts`, `maci.test.ts`) [[1]](diffhunk://#diff-f9832eb51d56e6da5a4d8519235721f8a58cf98d5fc6163f4b81cd01dfbb03a6R110) [[2]](diffhunk://#diff-23ed740be8293400fc65dd9a04d9fb39fc9fae4ef2fb81d1fc76676d1b120d38R8) [[3]](diffhunk://#diff-23ed740be8293400fc65dd9a04d9fb39fc9fae4ef2fb81d1fc76676d1b120d38L51-R56) [[4]](diffhunk://#diff-240e8243c932dc2481916823693f3f23ddad2990e0e9c7bc741e65fe766964e6L114-R120) [[5]](diffhunk://#diff-4f2fee4b1b1972f3a4ddc0bf28700645b54ee5b8c6bdcb378c7be9bf16274093R66-R69) [[6]](diffhunk://#diff-2982fb6d3c07c8d75edf336e8319a993ea596bff4e366e97426ae5c1513f2a8bL7-R7) [[7]](diffhunk://#diff-2982fb6d3c07c8d75edf336e8319a993ea596bff4e366e97426ae5c1513f2a8bR17)

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [X] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [X] I run and verified that all tests pass acording to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
