### PR TITLE
feat: add withdraw function

### DIFF
--- a/packages/contracts/contracts/interfaces/IPayoutStrategy.sol
+++ b/packages/contracts/contracts/interfaces/IPayoutStrategy.sol
@@ -6,14 +6,16 @@ pragma solidity ^0.8.20;
 interface IPayoutStrategy {
   /// @notice Strategy initialization params
   struct StrategyInit {
+    /// @notice The cooldown duration for withdrawal extra funds
+    uint256 cooldownTime;
+    /// @notice The custodian address who should receive leftover funds if tallying and cooldown period are over
+    address custodian;
     /// @notice The max contribution amount
     uint256 maxContribution;
     /// @notice The max cap
     uint256 maxCap;
     /// @notice The payout token
     address payoutToken;
-    /// @notice The deposit window duration (in seconds) after poll ends
-    uint256 depositWindow;
   }
 
   /// @notice Claim params
@@ -37,9 +39,15 @@ interface IPayoutStrategy {
   /// @notice Total deposited amount
   function totalAmount() external view returns (uint256);
 
+  /// @notice The cooldown timeout
+  function cooldown() external view returns (uint256);
+
   /// @notice Deposit amount
   /// @param amount The amount
   function deposit(uint256 amount) external;
+
+  /// @notice Withdraw extra amount
+  function withdraw() external;
 
   /// @notice Claim funds for recipient
   /// @param params The claim params

--- a/packages/contracts/deploy-config-example.json
+++ b/packages/contracts/deploy-config-example.json
@@ -76,11 +76,11 @@
       "useQuadraticVoting": false
     },
     "Tally": {
-      "withPause": true,
+      "cooldownTime": 604800,
+      "custodian": "0x0000000000000000000000000000000000000000",
       "maxCap": "10000000000000000000",
       "maxContribution": "5000000000000000000",
-      "payoutToken": "0x0000000000000000000000000000000000000000",
-      "depositWindow": "604800"
+      "payoutToken": "0x0000000000000000000000000000000000000000"
     }
   },
   "scroll_sepolia": {
@@ -159,11 +159,11 @@
       "useQuadraticVoting": false
     },
     "Tally": {
-      "withPause": true,
+      "cooldownTime": 604800,
+      "custodian": "0x0000000000000000000000000000000000000000",
       "maxCap": "10000000000000000000",
       "maxContribution": "5000000000000000000",
-      "payoutToken": "0x0000000000000000000000000000000000000000",
-      "depositWindow": "604800"
+      "payoutToken": "0x0000000000000000000000000000000000000000"
     }
   },
   "optimism": {
@@ -243,11 +243,11 @@
       "useQuadraticVoting": false
     },
     "Tally": {
-      "withPause": true,
+      "cooldownTime": 604800,
+      "custodian": "0x0000000000000000000000000000000000000000",
       "maxCap": "10000000000000000000",
       "maxContribution": "5000000000000000000",
-      "payoutToken": "0x0000000000000000000000000000000000000000",
-      "depositWindow": "604800"
+      "payoutToken": "0x0000000000000000000000000000000000000000"
     }
   },
   "arbitrum_sepolia": {
@@ -327,11 +327,11 @@
       "useQuadraticVoting": false
     },
     "Tally": {
-      "withPause": true,
+      "cooldownTime": 604800,
+      "custodian": "0x0000000000000000000000000000000000000000",
       "maxCap": "10000000000000000000",
       "maxContribution": "5000000000000000000",
-      "payoutToken": "0x0000000000000000000000000000000000000000",
-      "depositWindow": "604800"
+      "payoutToken": "0x0000000000000000000000000000000000000000"
     }
   },
   "localhost": {
@@ -411,11 +411,11 @@
       "useQuadraticVoting": false
     },
     "Tally": {
-      "withPause": true,
+      "cooldownTime": 604800,
+      "custodian": "0x0000000000000000000000000000000000000000",
       "maxCap": "10000000000000000000",
       "maxContribution": "5000000000000000000",
-      "payoutToken": "0x0000000000000000000000000000000000000000",
-      "depositWindow": "604800"
+      "payoutToken": "0x0000000000000000000000000000000000000000"
     }
   },
   "base_sepolia": {
@@ -495,11 +495,11 @@
       "useQuadraticVoting": false
     },
     "Tally": {
-      "withPause": true,
+      "cooldownTime": 604800,
+      "custodian": "0x0000000000000000000000000000000000000000",
       "maxCap": "10000000000000000000",
       "maxContribution": "5000000000000000000",
-      "payoutToken": "0x0000000000000000000000000000000000000000",
-      "depositWindow": "604800"
+      "payoutToken": "0x0000000000000000000000000000000000000000"
     }
   },
   "optimism_sepolia": {
@@ -584,11 +584,11 @@
       "useQuadraticVoting": false
     },
     "Tally": {
-      "withPause": true,
+      "cooldownTime": 604800,
+      "custodian": "0x0000000000000000000000000000000000000000",
       "maxCap": "10000000000000000000",
       "maxContribution": "5000000000000000000",
-      "payoutToken": "0x0000000000000000000000000000000000000000",
-      "depositWindow": "604800"
+      "payoutToken": "0x0000000000000000000000000000000000000000"
     }
   }
 }

--- a/packages/subgraph/schemas/schema.v1.graphql
+++ b/packages/subgraph/schemas/schema.v1.graphql
@@ -107,7 +107,6 @@ type Poll @entity {
 
 type Tally @entity {
   id: Bytes! # tally address
-  depositWindow: BigInt! # uint256 - duration in seconds after poll ends for deposits
   results: [TallyResult!]! @derivedFrom(field: "tally")
   claims: [Claim!]! @derivedFrom(field: "tally")
   deposits: [Deposit!]! @derivedFrom(field: "tally")

--- a/packages/subgraph/src/maci.ts
+++ b/packages/subgraph/src/maci.ts
@@ -5,7 +5,6 @@ import { DeployPoll as DeployPollEvent, SignUp as SignUpEvent, MACI as MaciContr
 import { Poll } from "../generated/schema";
 import { Poll as PollTemplate, Tally as TallyTemplate } from "../generated/templates";
 import { Poll as PollContract } from "../generated/templates/Poll/Poll";
-import { Tally as TallyContract } from "../generated/templates/Tally/Tally";
 
 import { ONE_BIG_INT, MESSAGE_TREE_ARITY } from "./utils/constants";
 import { createOrLoadMACI, createOrLoadUser, createOrLoadAccount, createOrLoadTally } from "./utils/entity";
@@ -49,11 +48,7 @@ export function handleDeployPoll(event: DeployPollEvent): void {
   // address of the new poll contract
   PollTemplate.create(Address.fromBytes(poll.id));
 
-  // Read depositWindow from the Tally contract
-  const tallyContract = TallyContract.bind(contracts.tally);
-  const depositWindow = tallyContract.depositWindow();
-
-  createOrLoadTally(contracts.tally, poll.id, depositWindow);
+  createOrLoadTally(contracts.tally, poll.id);
 
   // Start indexing the tally
   TallyTemplate.create(Address.fromBytes(contracts.tally));

--- a/packages/subgraph/src/utils/entity.ts
+++ b/packages/subgraph/src/utils/entity.ts
@@ -111,13 +111,12 @@ export const createOrLoadRecipient = (
   return recipient;
 };
 
-export const createOrLoadTally = (tally: Bytes, poll: Bytes, depositWindow: GraphBN): Tally => {
+export const createOrLoadTally = (tally: Bytes, poll: Bytes): Tally => {
   let entity = Tally.load(tally);
 
   if (!entity) {
     entity = new Tally(tally);
     entity.poll = poll;
-    entity.depositWindow = depositWindow;
     entity.save();
   }
 

--- a/packages/subgraph/tests/common.ts
+++ b/packages/subgraph/tests/common.ts
@@ -63,8 +63,4 @@ export function mockTallyContract(): void {
   createMockedFunction(DEFAULT_TALLY_ADDRESS, "poll", "poll():(address)").returns([
     ethereum.Value.fromAddress(DEFAULT_POLL_ADDRESS),
   ]);
-
-  createMockedFunction(DEFAULT_TALLY_ADDRESS, "depositWindow", "depositWindow():(uint256)").returns([
-    ethereum.Value.fromI32(604800), // 1 week in seconds
-  ]);
 }

--- a/packages/subgraph/tests/maci/maci.test.ts
+++ b/packages/subgraph/tests/maci/maci.test.ts
@@ -4,7 +4,7 @@ import { test, describe, afterEach, clearStore, assert, beforeAll } from "matchs
 
 import { Account, MACI, Poll, User } from "../../generated/schema";
 import { handleSignUp, handleDeployPoll } from "../../src/maci";
-import { DEFAULT_POLL_ADDRESS, mockMaciContract, mockPollContract, mockTallyContract } from "../common";
+import { DEFAULT_POLL_ADDRESS, mockMaciContract, mockPollContract } from "../common";
 
 import { createSignUpEvent, createDeployPollEvent } from "./utils";
 
@@ -14,7 +14,6 @@ describe("MACI", () => {
   beforeAll(() => {
     mockMaciContract();
     mockPollContract();
-    mockTallyContract();
   });
 
   afterEach(() => {


### PR DESCRIPTION
# Description

**Re-add withdrawal function with changes**
* Add withdraw function that can be called after a cooldown
* Funds can only be sent to a preconfigured custodian (Can set this to a gitcoin wallet for production deploy) - this balances having an escape hatch, while also reducing trust assumptions of the owner.
* Can call withdraw only after tallying is complete

**Minor simplifications**
* Removes `depositWindow` not essential as deposits can stop after tallying is complete 
* Removes pause functionality - no longer needed as this contract will be audited

**Other changes**
* Remove `duringDepositWindow` & `afterDepositWindow` modifiers
* `claim` can be called directly after tallying finishes

<!-- Please provide a detailed description of the pull request you are opening. -->

## Additional Notes

<!-- If there are any additional notes, requirements or special instructions related to this PR, please specify them here. -->

## Related issue(s)

<!-- Please list here with closing keywords any issues that this pull request is related to (fix #$ISSUE_NUMBER). -->

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I run and verified that all tests pass acording to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
